### PR TITLE
use `+` as the separator between Python version and PBS release

### DIFF
--- a/bin/pyenv-pbs-install
+++ b/bin/pyenv-pbs-install
@@ -359,7 +359,7 @@ install_pbs_release() {
         return 1
     fi
 
-    pbs_install_id="pbs-${python_version}-${pbs_release_tag}"
+    pbs_install_id="pbs-${python_version}+${pbs_release_tag}"
     local pbs_install_version_dir="$(pyenv-root)/versions/${pbs_install_id}"
     mkdir -p "$pbs_install_version_dir"
     tar xzf "$pbs_archive_path" --strip-components=1 -C "$pbs_install_version_dir"


### PR DESCRIPTION
The PBS project uses a `+` as the separator between the Python version and the PBS release tag. Let's use that convention for this plugin as well.