### PR TITLE
rename install command from `pbs-install` to `install-pbs`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
         ln -s ../.. pyenv-python-build-standalone
 
     - name: Install a recent PBS Python into pyenv.
-      run: pyenv pbs-install 3.12
+      run: pyenv install-pbs 3.12
 
     - name: Verify that the PBS Python actually runs
       run: |

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ This is a rough draft of a plugin for [`pyenv`](https://github.com/pyenv/pyenv) 
 
 ## Usage
 
-The plugin adds a new `pyenv pbs-install` subcommand which will download and install Python builds from the Python Build Standalone site. The metadata necessary to do that comes with the plugin.
+The plugin adds a new `pyenv install-pbs` subcommand which will download and install Python builds from the Python Build Standalone site. The metadata necessary to do that comes with the plugin.
 
-For example, install the latest Python 3.12 patchlevel and PBS release tag from PBS: `pyenv pbs-install 3.12`
+For example, install the latest Python 3.12 patchlevel and PBS release tag from PBS: `pyenv install-pbs 3.12`
 
-Or install a specific PBS release by running: `pyenv pbs-install 3.13.1 20241206`
+Or install a specific PBS release by running: `pyenv install-pbs 3.13.1 20241206`
 
-The name of the particular PBS version will be `pbs-PYTHON_VERSION-PBS_RELEASE_TAG`. You can then use that name with `pyenv global` to make it visible on the system.
+The name of the particular PBS version will be `pbs-PYTHON_VERSION+PBS_RELEASE_TAG`. You can then use that name with `pyenv global` to make it visible on the system.

--- a/bin/pyenv-install-pbs
+++ b/bin/pyenv-install-pbs
@@ -2,14 +2,14 @@
 #
 # Summary: Install a Python Build Standalone version of Python.
 #
-# Usage: pyenv pbs-install [-fs] <python_version> [pbs_release]
-#        pyenv pbs-install -l|--list
-#        pyenv pbs-install --version
+# Usage: pyenv install-pbs [-fs] <python_version> [pbs_release]
+#        pyenv install-pbs -l|--list
+#        pyenv install-pbs --version
 #
 #   -l/--list           List all available versions.
 #   -f/--force          Install even if the version appears to be installed already.
 #   -s/--skip-existing  Skip if the version appears to be installed already.
-#   --version           Print the version of the pbs-install plugin.
+#   --version           Print the version of the install-pbs plugin.
 #
 #   python_version>   A Python version such as 3.9 or 3.9.20. If only the major/minor version numbers
 #                     are specified, then the latest patchlevel for the given version will be installed.
@@ -87,8 +87,8 @@ sort_version_list() {
     local output_array_name=$1
     shift
 
-    local tmp_file1=$(mktemp -t pbs-install.XXXXXX)
-    local tmp_file2=$(mktemp -t pbs-install.XXXXXX)
+    local tmp_file1=$(mktemp -t install-pbs.XXXXXX)
+    local tmp_file2=$(mktemp -t install-pbs.XXXXXX)
 
     printf "%s\n" "$@" > "$tmp_file1"
     sort -V -r < "$tmp_file1" > "$tmp_file2"
@@ -106,7 +106,7 @@ shopt -u nullglob
 
 # Display usage for this tool.
 usage() {
-  pyenv-help pbs-install 2>/dev/null
+  pyenv-help install-pbs 2>/dev/null
   [ -z "$1" ] || exit "$1"
 }
 
@@ -342,7 +342,7 @@ install_pbs_release() {
 
     # Download the PBS distribution.
     # TODO: Cache the downloads locally.
-    local download_dir="$(mktemp -d -t pbs-install.XXXXXX)"
+    local download_dir="$(mktemp -d -t install-pbs.XXXXXX)"
     http_get_curl "$download_url" "${download_dir}/cpython.tar.gz"
     echo "Downloaded ${download_url}."
     local pbs_archive_path="${download_dir}/cpython.tar.gz"


### PR DESCRIPTION
Rename the install command to `install-pbs` so it has more similarity with the existing `pyenv install` command.