### PR TITLE
fix bug in selecting the latest release tag for a Python version

### DIFF
--- a/bin/pyenv-install-pbs
+++ b/bin/pyenv-install-pbs
@@ -277,8 +277,8 @@ choose_pbs_release_tag() {
 
     # Sort the versions and choose the latest one.
     local -a candidate_pbs_release_tags
-    sort_version_list candidate_pbs_release_tags "${candidate_pbs_release_tags[@]}"
-    echo "${candidate_pbs_release_tags[0]}"
+    sort_version_list sorted_candidate_pbs_release_tags "${candidate_pbs_release_tags[@]}"
+    echo "${sorted_candidate_pbs_release_tags[0]}"
 }
 
 # Find the download definitions directory for the given Python version and PBS release tag.


### PR DESCRIPTION
`sort_version_list` requires the output array name to not be the same name as any input array name, otherwise the sort does not work correctly.