### PR TITLE
update scraping script to not re-do prior scraping

### DIFF
--- a/scripts/gen.sh
+++ b/scripts/gen.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+dir="$(dirname $BASH_SOURCE)"
+if [ ! -d "${dir}/.venv" ]; then
+  python3 -m venv "${dir}/.venv"
+  "${dir}/.venv/bin/pip" install -r "${dir}/requirements.txt"
+fi
+
+exec "${dir}/.venv/bin/python3" "${dir}/generate_defs.py" "$@"

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,3 @@
+packaging
 pygithub
 requests


### PR DESCRIPTION
Several improvements to the scraping script:

- By default, only scrape releases newer than the last known release tag.
- Add shell script to make venv and then invoke the Python generator script.