### PR TITLE
fix directory parsing in `gen.sh`

### DIFF
--- a/scripts/gen.sh
+++ b/scripts/gen.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-dir="$(dirname $BASH_SOURCE)"
-if [ ! -d "${dir}/.venv" ]; then
+dir="$(dirname $0)"
+if [ ! -d "${dir:=.}/.venv" ]; then
   python3 -m venv "${dir}/.venv"
   "${dir}/.venv/bin/pip" install -r "${dir}/requirements.txt"
 fi


### PR DESCRIPTION
- Don't use $BASH_SOURCE since Bash may not be used for `/bin/sh` on GitHub Actions.
- If the directory is blank, assume `.` so we substitute correctly when a path might be joined with `/`