### PR TITLE
update PBS GitHub org to `astral-sh`

### DIFF
--- a/scripts/generate_defs.py
+++ b/scripts/generate_defs.py
@@ -90,7 +90,7 @@ def main() -> None:
         raise Exception("This helper script must be run from the root of the repository.")
 
     github = _github()
-    pbs_repo = github.get_repo("indygreg/python-build-standalone")
+    pbs_repo = github.get_repo("astral-sh/python-build-standalone")
 
     print("Downloading PBS release metadata.")
     releases = pbs_repo.get_releases()


### PR DESCRIPTION
GitHub organization `astral-sh` took over ownership of Python Build Standalone. See the [Astral blog](https://astral.sh/blog/python-build-standalone) and the [blog of the PBS project founder](https://gregoryszorc.com/blog/2024/12/03/transferring-python-build-standalone-stewardship-to-astral/) for more information.