### PR TITLE
allow repository writes from the scraping workflow

### DIFF
--- a/.github/workflows/check-for-new-releases.yaml
+++ b/.github/workflows/check-for-new-releases.yaml
@@ -6,6 +6,9 @@ on:
 jobs:
   scrape_pbs_releases:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -31,6 +34,7 @@ jobs:
 
         git config user.name "${GITHUB_ACTOR}"
         git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
 
         branch_name="scrape_$(date '+%Y-%m-%d-%H-%M')"
         git checkout -b "$branch_name"


### PR DESCRIPTION
Enable permissions on GitHub token to enable writing to repository from the scraping workflow.